### PR TITLE
DO NOT MERGE — temporary test of launch-workflows#93

### DIFF
--- a/.github/workflows/pull-request-check-terraform.yml
+++ b/.github/workflows/pull-request-check-terraform.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: read
       id-token: write
       statuses: write
-    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-terraform-check.yml@edddecdce4590f94f30d0fdfdf991d8a692fe8dd
+    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-terraform-check.yml@c78558b6bd58b1157af05fe1b5bc9957576de55f
     with:
       auth_method: ${{ startsWith(github.event.repository.name, 'tf-aws') && 'aws' ||
         startsWith(github.event.repository.name, 'tf-az') && 'azure' || '' }}


### PR DESCRIPTION
Throwaway draft to exercise `launch-workflows#93` (Terraform provider plugin cache) end to end.

Nothing in `launch-workflows` invokes `reusable-terraform-check.yml`, so that PR's own CI never executes the workflow it changes. This points this repo's check at the branch so the modified workflow actually runs.

**Will be closed as soon as the Lint Module job is observed. Do not merge, do not review.**

Made with [Cursor](https://cursor.com)